### PR TITLE
Implement support for non-typed ACL resources

### DIFF
--- a/src/authorization.js
+++ b/src/authorization.js
@@ -207,6 +207,8 @@ class Authorization {
    * @return {Boolean}
    */
   allowsMode (accessMode) {
+    // Normalize the access mode
+    accessMode = Authorization.acl[accessMode.toUpperCase()] || accessMode
     return this.accessModes[accessMode]
   }
   /**

--- a/src/permission-set.js
+++ b/src/permission-set.js
@@ -33,6 +33,7 @@ var CONTAINER = 'container'
  * @param aclUrl
  * @param isContainer
  * @param [options={}] {Object} Options hashmap
+ * @param [options.graph] {Graph} Parsed RDF graph of the ACL resource
  * @param [options.rdf] {RDF} RDF Library
  * @param [options.strictOrigin] {Boolean} Enforce strict origin?
  * @param [options.origin] {String} Origin URI to enforce, relevant
@@ -95,6 +96,10 @@ function PermissionSet (resourceUrl, aclUrl, isContainer, options) {
    * @type {SolidWebClient}
    */
   this.webClient = options.webClient
+  // Optionally initialize from a given parsed graph
+  if (options.graph) {
+    this.initFromGraph(options.graph)
+  }
 }
 
 /**

--- a/src/permission-set.js
+++ b/src/permission-set.js
@@ -27,7 +27,21 @@ var ns = require('solid-namespace')
 var RESOURCE = 'resource'
 var CONTAINER = 'container'
 
-function PermissionSet (resourceUrl, aclUrl, isContainer, rdf, webClient) {
+/**
+ * @class PermissionSet
+ * @param resourceUrl
+ * @param aclUrl
+ * @param isContainer
+ * @param [options={}] {Object} Options hashmap
+ * @param [options.rdf] {RDF} RDF Library
+ * @param [options.strictOrigin] {Boolean} Enforce strict origin?
+ * @param [options.origin] {String} Origin URI to enforce, relevant
+ *   if strictOrigin is set to true
+ * @param [options.webClient] {SolidWebClient}
+ * @constructor
+ */
+function PermissionSet (resourceUrl, aclUrl, isContainer, options) {
+  options = options || {}
   /**
    * Hashmap of all Authorizations in this permission set, keyed by a hashed
    * combination of an agent's/group's webId and the resourceUrl.
@@ -47,7 +61,7 @@ function PermissionSet (resourceUrl, aclUrl, isContainer, rdf, webClient) {
    * @property rdf
    * @type {RDF}
    */
-  this.rdf = rdf
+  this.rdf = options.rdf
   /**
    * Whether this permission set is for a 'container' or a 'resource'.
    * Determines whether or not the inherit/'acl:default' attribute is set on
@@ -63,10 +77,24 @@ function PermissionSet (resourceUrl, aclUrl, isContainer, rdf, webClient) {
    */
   this.resourceUrl = resourceUrl
   /**
+   * Should this permission set enforce "strict origin" policy?
+   * (If true, uses `options.origin` parameter)
+   * @property strictOrigin
+   * @type {Boolean}
+   */
+  this.strictOrigin = options.strictOrigin
+  /**
+   * Contents of the request's `Origin:` header.
+   * (used only if `strictOrigin` parameter is set to true)
+   * @property origin
+   * @type {String}
+   */
+  this.origin = options.origin
+  /**
    * Solid REST client (optionally injected), used by save() and clear().
    * @type {SolidWebClient}
    */
-  this.webClient = webClient
+  this.webClient = options.webClient
 }
 
 /**

--- a/test/resources/untyped-acl-ttl.js
+++ b/test/resources/untyped-acl-ttl.js
@@ -1,0 +1,11 @@
+module.exports = `@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<#authorization>
+    # Not present: a acl:Authorization;
+
+    acl:agent 
+        <https://alice.example.com/#me>;
+    acl:accessTo <https://alice.example.com/docs/file1>;
+    acl:mode
+        acl:Read, acl:Write, acl:Control.`

--- a/test/unit/authorization-test.js
+++ b/test/unit/authorization-test.js
@@ -39,6 +39,13 @@ test('a new Authorization for a container', function (t) {
   t.end()
 })
 
+test('Authorization allowsMode() test', function (t) {
+  let auth = new Authorization()
+  auth.addMode(acl.WRITE)
+  t.ok(auth.allowsMode(acl.WRITE), 'auth.allowsMode() should work')
+  t.end()
+})
+
 test('an Authorization allows editing permission modes', function (t) {
   let auth = new Authorization()
   auth.addMode(acl.CONTROL)

--- a/test/unit/permission-set-test.js
+++ b/test/unit/permission-set-test.js
@@ -130,7 +130,7 @@ test('a PermissionSet() for a resource (not container)', function (t) {
 
 test('a PermissionSet can be initialized from an .acl resource', function (t) {
   let ps = new PermissionSet(containerUrl, containerAclUrl,
-    PermissionSet.CONTAINER, rdf)
+    PermissionSet.CONTAINER, {rdf: rdf})
   ps.initFromGraph(parsedAclGraph)
   // Check to make sure Alice's authorizations were read in correctly
   let auth = ps.permissionFor(aliceWebId)
@@ -206,7 +206,7 @@ test('PermissionSet equals test 4', function (t) {
 
 test('PermissionSet serialized & deserialized round trip test', function (t) {
   var ps = new PermissionSet(containerUrl, containerAclUrl,
-    PermissionSet.CONTAINER, rdf)
+    PermissionSet.CONTAINER, {rdf: rdf})
   ps.initFromGraph(parsedAclGraph)
   let auth = ps.permissionFor(aliceWebId)
   // console.log(ps.serialize())
@@ -219,7 +219,7 @@ test('PermissionSet serialized & deserialized round trip test', function (t) {
       let parsedGraph = parseGraph(rdf, containerAclUrl, serializedTurtle,
         'text/turtle')
       let ps2 = new PermissionSet(containerUrl, containerAclUrl,
-        PermissionSet.CONTAINER, rdf)
+        PermissionSet.CONTAINER, {rdf: rdf})
       ps2.initFromGraph(parsedGraph)
       // console.log(ps2.serialize())
       t.ok(ps.equals(ps2),
@@ -228,12 +228,14 @@ test('PermissionSet serialized & deserialized round trip test', function (t) {
     })
 })
 
-test.only('PermissionSet allowsPublic() test', function (t) {
+test('PermissionSet allowsPublic() test', function (t) {
   var ps = new PermissionSet(containerUrl, containerAclUrl,
-    PermissionSet.CONTAINER, rdf)
+    PermissionSet.CONTAINER, {rdf: rdf})
   ps.initFromGraph(parsedAclGraph)
   let otherUrl = 'https://alice.example.com/profile/card'
-  t.ok(ps.allowsPublic(acl.READ, otherUrl))
-  t.notOk(ps.allowsPublic(acl.WRITE, otherUrl))
+  t.ok(ps.allowsPublic(acl.READ, otherUrl),
+    'Alice should have read access to a public read document')
+  t.notOk(ps.allowsPublic(acl.WRITE, otherUrl),
+    'Alice should not have write access to a public read-only document')
   t.end()
 })

--- a/test/unit/permission-set-test.js
+++ b/test/unit/permission-set-test.js
@@ -130,8 +130,7 @@ test('a PermissionSet() for a resource (not container)', function (t) {
 
 test('a PermissionSet can be initialized from an .acl resource', function (t) {
   let ps = new PermissionSet(containerUrl, containerAclUrl,
-    PermissionSet.CONTAINER, {rdf: rdf})
-  ps.initFromGraph(parsedAclGraph)
+    PermissionSet.CONTAINER, { graph: parsedAclGraph, rdf: rdf })
   // Check to make sure Alice's authorizations were read in correctly
   let auth = ps.permissionFor(aliceWebId)
   t.ok(auth, 'Container acl should have an authorization for Alice')
@@ -206,8 +205,7 @@ test('PermissionSet equals test 4', function (t) {
 
 test('PermissionSet serialized & deserialized round trip test', function (t) {
   var ps = new PermissionSet(containerUrl, containerAclUrl,
-    PermissionSet.CONTAINER, {rdf: rdf})
-  ps.initFromGraph(parsedAclGraph)
+    PermissionSet.CONTAINER, { graph: parsedAclGraph, rdf: rdf })
   let auth = ps.permissionFor(aliceWebId)
   // console.log(ps.serialize())
   t.ok(ps.equals(ps), 'A PermissionSet should equal itself')
@@ -219,8 +217,7 @@ test('PermissionSet serialized & deserialized round trip test', function (t) {
       let parsedGraph = parseGraph(rdf, containerAclUrl, serializedTurtle,
         'text/turtle')
       let ps2 = new PermissionSet(containerUrl, containerAclUrl,
-        PermissionSet.CONTAINER, {rdf: rdf})
-      ps2.initFromGraph(parsedGraph)
+        PermissionSet.CONTAINER, { graph: parsedGraph, rdf: rdf })
       // console.log(ps2.serialize())
       t.ok(ps.equals(ps2),
         'A PermissionSet serialized and re-parsed should equal the original one')
@@ -230,8 +227,18 @@ test('PermissionSet serialized & deserialized round trip test', function (t) {
 
 test('PermissionSet allowsPublic() test', function (t) {
   var ps = new PermissionSet(containerUrl, containerAclUrl,
-    PermissionSet.CONTAINER, {rdf: rdf})
-  ps.initFromGraph(parsedAclGraph)
+    PermissionSet.CONTAINER, { graph: parsedAclGraph, rdf: rdf })
+  let otherUrl = 'https://alice.example.com/profile/card'
+  t.ok(ps.allowsPublic(acl.READ, otherUrl),
+    'Alice should have read access to a public read document')
+  t.notOk(ps.allowsPublic(acl.WRITE, otherUrl),
+    'Alice should not have write access to a public read-only document')
+  t.end()
+})
+
+test('PermissionSet allows() test', function (t) {
+  var ps = new PermissionSet(containerUrl, containerAclUrl,
+    PermissionSet.CONTAINER, { graph: parsedAclGraph, rdf: rdf })
   let otherUrl = 'https://alice.example.com/profile/card'
   t.ok(ps.allowsPublic(acl.READ, otherUrl),
     'Alice should have read access to a public read document')

--- a/test/unit/permission-set-test.js
+++ b/test/unit/permission-set-test.js
@@ -246,3 +246,16 @@ test('PermissionSet allows() test', function (t) {
     'Alice should not have write access to a public read-only document')
   t.end()
 })
+
+test('PermissionSet init from untyped ACL test', function (t) {
+  let rawAclSource = require('../resources/untyped-acl-ttl')
+  let resourceUrl = 'https://alice.example.com/docs/file1'
+  let aclUrl = 'https://alice.example.com/docs/file1.acl'
+  let parsedAclGraph = parseGraph(rdf, aclUrl, rawAclSource, 'text/turtle')
+  let isContainer = false
+  let ps = new PermissionSet(resourceUrl, aclUrl, isContainer,
+    { graph: parsedAclGraph, rdf: rdf })
+  t.ok(ps.count(),
+    'Permission set should init correctly without acl:Authorization type')
+  t.end()
+})


### PR DESCRIPTION
Support cases where the ACL file lacks acl:Authorization rdfs:type statements.
Also:

- Normalize access mode string in Authorization.allowsMode()
- Refactor PermissionSet() constructor signature