### PR TITLE
Fix checkAccess() + Append mode error

### DIFF
--- a/src/authorization.js
+++ b/src/authorization.js
@@ -217,6 +217,9 @@ class Authorization {
   allowsMode (accessMode) {
     // Normalize the access mode
     accessMode = Authorization.acl[accessMode.toUpperCase()] || accessMode
+    if (accessMode === Authorization.acl.APPEND) {
+      return this.allowsAppend()  // Handle the Append special case
+    }
     return this.accessModes[accessMode]
   }
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@
  */
 
 var PermissionSet = require('./permission-set')
+var Authorization = require('./authorization')
 /**
  * Clears (deletes) an ACL resource for a given resource url.
  * Usage:
@@ -76,3 +77,4 @@ function getPermissions (resourceUrl, webClient, rdf) {
 module.exports.clearPermissions = clearPermissions
 module.exports.getPermissions = getPermissions
 module.exports.PermissionSet = PermissionSet
+module.exports.Authorization = Authorization

--- a/src/permission-set.js
+++ b/src/permission-set.js
@@ -393,7 +393,9 @@ class PermissionSet {
    * @return {Boolean}
    */
   checkOrigin (authorization) {
-    if (!this.enforceOrigin()) {
+    if (!this.strictOrigin ||  // Enforcement turned off in server config
+        !this.origin ||  // No origin - not a script, do not enforce origin
+        this.origin === this.host) {  // same origin is trusted
       return true
     }
     return authorization.allowsOrigin(this.origin) ||

--- a/src/permission-set.js
+++ b/src/permission-set.js
@@ -52,8 +52,7 @@ const GROUP_INDEX = 'groups'
  * @constructor
  */
 class PermissionSet {
-  constructor (resourceUrl, aclUrl, isContainer, options) {
-    options = options || {}
+  constructor (resourceUrl, aclUrl, isContainer, options = {}) {
     /**
      * Hashmap of all Authorizations in this permission set, keyed by a hashed
      * combination of an agent's/group's webId and the resourceUrl.

--- a/src/permission-set.js
+++ b/src/permission-set.js
@@ -398,8 +398,8 @@ class PermissionSet {
         this.origin === this.host) {  // same origin is trusted
       return true
     }
-    return authorization.allowsOrigin(this.origin) ||
-        authorization.allowsOrigin(this.host)
+    // If not same origin, check that the origin is in the explicit ACL list
+    return authorization.allowsOrigin(this.origin)
   }
 
   /**

--- a/src/permission-set.js
+++ b/src/permission-set.js
@@ -450,16 +450,6 @@ class PermissionSet {
   }
 
   /**
-   * Tests whether the permission set should enforce a strict origin for the
-   * request.
-   * @method enforceOrigin
-   * @return {Boolean}
-   */
-  enforceOrigin () {
-    return this.strictOrigin && this.origin
-  }
-
-  /**
    * Returns whether or not this permission set is equal to another one.
    * A PermissionSet is considered equal to another one iff:
    * - It has the same number of authorizations, and each of those authorizations

--- a/test/unit/check-access-test.js
+++ b/test/unit/check-access-test.js
@@ -6,6 +6,21 @@ const acl = Authorization.acl
 const PermissionSet = require('../../src/permission-set')
 const aliceWebId = 'https://alice.example.com/#me'
 
+test('PermissionSet checkAccess() test - Append access', t => {
+  let resourceUrl = 'https://alice.example.com/docs/file1'
+  let aclUrl = 'https://alice.example.com/docs/.acl'
+  let ps = new PermissionSet(resourceUrl, aclUrl)
+  ps.addPermission(aliceWebId, acl.WRITE)
+  ps.checkAccess(resourceUrl, aliceWebId, acl.APPEND)
+    .then(result => {
+      t.ok(result, 'Alice should have Append access implied by Write access')
+    })
+    .catch(err => {
+      t.fail(err)
+    })
+  t.end()
+})
+
 test('PermissionSet checkAccess() test - accessTo', function (t) {
   let containerUrl = 'https://alice.example.com/docs/'
   let containerAclUrl = 'https://alice.example.com/docs/.acl'


### PR DESCRIPTION
Fix case where an authorization had Write access, and `checkAccess(resource, user, 'Append')` was failing