### PR TITLE
Unbreak installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,10 @@
   "description": "Web Access Control based permissions library",
   "main": "./lib/index",
   "files": [
-    "src",
     "lib"
   ],
   "scripts": {
     "build": "babel src -d lib",
-    "postinstall": "npm run build",
     "prepublish": "npm test && npm run build",
     "standard": "standard *.js src/*.js",
     "tape": "tape test/unit/*.js",
@@ -42,11 +40,11 @@
   },
   "homepage": "https://github.com/solid/solid-permissions",
   "dependencies": {
-    "babel-cli": "^6.14.0",
-    "babel-preset-es2015": "^6.14.0",
     "solid-namespace": "0.1.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.14.0",
+    "babel-preset-es2015": "^6.14.0",
     "rdflib": "^0.12.1",
     "sinon": "^1.17.6",
     "solid-web-client": "0.0.9",


### PR DESCRIPTION
Build should not be run on a `postinstall` hook but on `prepublish`.