### PR TITLE
Implement Ad Hoc Group listing support (acl:agentGroup)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "babel-cli": "^6.14.0",
     "babel-preset-es2015": "^6.14.0",
-    "rdflib": "^0.12.1",
+    "rdflib": "^0.13.0",
     "sinon": "^1.17.6",
     "solid-web-client": "0.0.9",
     "standard": "^5.4.1",

--- a/src/authorization.js
+++ b/src/authorization.js
@@ -5,17 +5,13 @@
  * @module authorization
  */
 
-var vocab = require('solid-namespace')
+const vocab = require('solid-namespace')
 const { acl } = require('./modes')
-
-/**
- * Returns a set of convenience constants, for use with `addPermission()` etc.
- * Exported as `Authorization.acl`.
- */
+const GroupListing = require('./group-listing')
 
 /**
  * Models an individual authorization object, for a single resource and for
- * a single webId (either agent or agentClass). See the comments at the top
+ * a single webId (either agent or group). See the comments at the top
  * of the PermissionSet module for design assumptions.
  * Low-level, not really meant to be instantiated directly. Use
  * `permissionSet.addPermission()` instead.
@@ -25,11 +21,11 @@ class Authorization {
   /**
    * @param resourceUrl {String} URL of the resource (`acl:accessTo`) for which
    *   this authorization is intended.
-   * @param [inherited] {Boolean} Should this authorization be inherited (contain
-   *   `acl:default`). Used for container ACLs. Defaults to null/false.
+   * @param [inherited=false] {Boolean} Should this authorization be inherited (contain
+   *   `acl:default`). Used for container ACLs.
    * @constructor
    */
-  constructor (resourceUrl, inherited) {
+  constructor (resourceUrl, inherited = false) {
     /**
      * Hashmap of all of the access modes (`acl:Write` etc) granted to an agent
      * or group in this authorization. Modified via `addMode()` and `removeMode()`
@@ -54,8 +50,9 @@ class Authorization {
      */
     this.agent = null
     /**
-     * URL of a group resource (`acl:agentClass`). Inside an authorization,
-     * mutually exclusive with the `agent` property. Set via `setGroup()`.
+     * URL of a group resource (`acl:agentGroup` or `acl:agentClass`). Inside an
+     * authorization, mutually exclusive with the `agent` property.
+     * Set via `setGroup()`.
      * @property group
      * @type {String}
      */
@@ -283,20 +280,20 @@ class Authorization {
    * @return {Boolean}
    */
   equals (auth) {
-    var sameAgent = this.agent === auth.agent
-    var sameGroup = this.group === auth.group
-    var sameUrl = this.resourceUrl === auth.resourceUrl
-    var myModeKeys = Object.keys(this.accessModes)
-    var authModeKeys = Object.keys(auth.accessModes)
-    var sameNumberModes = myModeKeys.length === authModeKeys.length
-    var sameInherit =
+    let sameAgent = this.agent === auth.agent
+    let sameGroup = this.group === auth.group
+    let sameUrl = this.resourceUrl === auth.resourceUrl
+    let myModeKeys = Object.keys(this.accessModes)
+    let authModeKeys = Object.keys(auth.accessModes)
+    let sameNumberModes = myModeKeys.length === authModeKeys.length
+    let sameInherit =
       JSON.stringify(this.inherited) === JSON.stringify(auth.inherited)
-    var sameModes = true
+    let sameModes = true
     myModeKeys.forEach((key) => {
       if (!auth.accessModes[ key ]) { sameModes = false }
     })
-    var sameMailTos = JSON.stringify(this.mailTo) === JSON.stringify(auth.mailTo)
-    var sameOrigins =
+    let sameMailTos = JSON.stringify(this.mailTo) === JSON.stringify(auth.mailTo)
+    let sameOrigins =
       JSON.stringify(this.originsAllowed) === JSON.stringify(auth.originsAllowed)
     return sameAgent && sameGroup && sameUrl && sameNumberModes && sameModes &&
       sameInherit && sameMailTos && sameOrigins
@@ -314,7 +311,7 @@ class Authorization {
     if (!this.webId || !this.resourceUrl) {
       throw new Error('Cannot call hashFragment() on an incomplete authorization')
     }
-    var hashFragment = hashFragmentFor(this.webId(), this.resourceUrl,
+    let hashFragment = hashFragmentFor(this.webId(), this.resourceUrl,
       this.accessType)
     return hashFragment
   }
@@ -403,7 +400,8 @@ class Authorization {
    * Returns an array of RDF statements representing this authorization.
    * Used by `PermissionSet.serialize()`.
    * @method rdfStatements
-   * @return {Array<Statement>} List of RDF statements representing this Auth,
+   * @param rdf {RDF} RDF Library
+   * @return {Array<Triple>} List of RDF statements representing this Auth,
    *   or an empty array if this authorization is invalid.
    */
   rdfStatements (rdf) {
@@ -415,16 +413,16 @@ class Authorization {
     if (this.virtual) {
       return []
     }
-    var statement
-    var fragment = rdf.namedNode('#' + this.hashFragment())
-    var ns = vocab(rdf)
-    var statements = [
+    let statement
+    let fragment = rdf.namedNode('#' + this.hashFragment())
+    let ns = vocab(rdf)
+    let statements = [
       rdf.triple(
         fragment,
         ns.rdf('type'),
         ns.acl('Authorization'))
     ]
-    if (this.agent) {
+    if (this.isAgent()) {
       statement = rdf.triple(fragment, ns.acl('agent'), rdf.namedNode(this.agent))
       statements.push(statement)
     }
@@ -435,15 +433,17 @@ class Authorization {
         statements.push(statement)
       })
     }
-    if (this.group) {
-      statement = rdf.triple(fragment, ns.acl('agentClass'),
-        rdf.namedNode(this.group))
+    if (this.isPublic()) {
+      statement = rdf.triple(fragment, ns.acl('agentClass'), ns.foaf('Agent'))
+      statements.push(statement)
+    } else if (this.isGroup()) {
+      statement = rdf.triple(fragment, ns.acl('agentGroup'), rdf.namedNode(this.group))
       statements.push(statement)
     }
     statement = rdf.triple(fragment, ns.acl('accessTo'),
       rdf.namedNode(this.resourceUrl))
     statements.push(statement)
-    var modes = Object.keys(this.accessModes)
+    let modes = Object.keys(this.accessModes)
     modes.forEach((accessMode) => {
       statement = rdf.triple(fragment, ns.acl('mode'), rdf.namedNode(accessMode))
       statements.push(statement)
@@ -499,13 +499,13 @@ class Authorization {
    *   representation of the access mode, or an RDF `acl:mode` triple.
    * @returns {removeMode}
    */
-  removeOrigin (accessMode) {
-    if (Array.isArray(accessMode)) {
-      accessMode.forEach((ea) => {
+  removeOrigin (origin) {
+    if (Array.isArray(origin)) {
+      origin.forEach((ea) => {
         this.removeOriginSingle(ea)
       })
     } else {
-      this.removeOriginSingle(accessMode)
+      this.removeOriginSingle(origin)
     }
     return this
   }
@@ -525,13 +525,14 @@ class Authorization {
   }
 
   /**
-   * Sets the agent WebID for this authorization. Implemented as `setAgent()`
-   * setter method to enforce mutual exclusivity with `group` property, until
-   * ES6 setter methods become available.
+   * Sets the agent WebID for this authorization.
    * @method setAgent
-   * @param agent {String|Quad} Agent URL (or `acl:agent` RDF triple).
+   * @param agent {string|Quad|GroupListing} Agent URL (or `acl:agent` RDF triple).
    */
   setAgent (agent) {
+    if (agent instanceof GroupListing) {
+      return this.setGroup(agent)
+    }
     if (typeof agent !== 'string') {
       // This is an RDF statement
       agent = agent.object.value
@@ -549,22 +550,23 @@ class Authorization {
   }
 
   /**
-   * Sets the group WebID for this authorization. Implemented as `setGroup()`
-   * setter method to enforce mutual exclusivity with `agent` property, until
-   * ES6 setter methods become available.
+   * Sets the group WebID for this authorization.
    * @method setGroup
-   * @param agentClass {String|Statement} Group URL (or `acl:agentClass` RDF
+   * @param group {string|Triple|GroupListing} Group URL (or `acl:agentClass` RDF
    *   triple).
    */
-  setGroup (agentClass) {
-    if (typeof agentClass !== 'string') {
-      // This is an RDF statement
-      agentClass = agentClass.object.value
-    }
+  setGroup (group) {
     if (this.agent) {
       throw new Error('Cannot set group, authorization already has an agent set')
     }
-    this.group = agentClass
+    if (group instanceof GroupListing) {
+      group = group.listing
+    }
+    if (typeof group !== 'string') {
+      // This is an RDF statement
+      group = group.object.value
+    }
+    this.group = group
   }
 
   /**
@@ -597,7 +599,7 @@ class Authorization {
  */
 function hashFragmentFor (webId, resourceUrl,
                           authType = acl.ACCESS_TO) {
-  var hashKey = webId + '-' + resourceUrl + '-' + authType
+  let hashKey = webId + '-' + resourceUrl + '-' + authType
   return hashKey
 }
 

--- a/src/group-listing.js
+++ b/src/group-listing.js
@@ -1,0 +1,118 @@
+const vocab = require('solid-namespace')
+
+/**
+ * Ad Hoc ACL Group Listing
+ * @see https://github.com/solid/web-access-control-spec#groups-of-agents
+ * @class GroupListing
+ */
+class GroupListing {
+  /**
+   * @constructor
+   * @param [options={}] {Object} Options hashmap
+   * @param [options.uri] {string|NamedNode} Group URI as appears in ACL file
+   *   (e.g. `https://example.com/groups#management`)
+   * @param [options.uid] {string} Value of `vcard:hasUID` object
+   * @param [options.members={}] {Object} Hashmap of group members, by webId
+   * @param [options.listing] {string|NamedNode} Group listing document URI
+   * @param [options.rdf] {RDF} RDF library
+   * @param [options.graph] {Graph} Parsed graph of the group listing document
+   */
+  constructor (options = {}) {
+    this.uri = options.uri
+    this.uid = options.uid
+    this.members = options.members || {}
+    this.listing = options.listing
+    this.rdf = options.rdf
+    this.graph = options.graph
+    if (this.rdf && this.graph) {
+      this.initFromGraph(this.graph, this.rdf)
+    }
+  }
+
+  /**
+   * Factory function, returns a group listing, loaded and initialized with the
+   * graph from its uri.
+   * @static
+   * @param uri {string}
+   * @param fetchGraph {Function}
+   * @param rdf {RDF}
+   * @param options {Object} Options hashmap, passed through to fetchGraph()
+   * @return {Promise<GroupListing>}
+   */
+  static loadFrom (uri, fetchGraph, rdf, options = {}) {
+    let group = new GroupListing({ uri, rdf })
+    return fetchGraph(uri, options)
+      .then(graph => {
+        return group.initFromGraph(uri, graph)
+      })
+      .catch(err => {
+        console.error(err)
+        return null
+      })
+  }
+
+  /**
+   * Adds a member's web id uri to the listing
+   * @param webId {string|NamedNode}
+   * @return {GroupListing} Chainable
+   */
+  addMember (webId) {
+    if (webId.value) {
+      webId = webId.value
+    }
+    this.members[webId] = true
+    return this
+  }
+
+  /**
+   * Returns the number of members in this listing
+   * @return {Number}
+   */
+  get count () {
+    return Object.keys(this.members).length
+  }
+
+  /**
+   * Tests if a webId uri is present in the members list
+   * @param webId {string|NamedNode}
+   * @return {Boolean}
+   */
+  hasMember (webId) {
+    if (webId.value) {
+      webId = webId.value
+    }
+    return this.members[webId]
+  }
+
+  /**
+   * @method initFromGraph
+   * @param [uri] {string|NamedNode} Group URI as appears in ACL file
+   *   (e.g. `https://example.com/groups#management`)
+   * @param [graph] {Graph} Parsed graph
+   * @param [rdf] {RDF}
+   * @throws {Error}
+   * @return {GroupListing} Chainable
+   */
+  initFromGraph (uri = this.uri, graph = this.graph, rdf = this.rdf) {
+    if (!uri) {
+      throw new Error('Group URI required to init from graph')
+    }
+    if (!graph || !rdf) {
+      throw new Error('initFromGraph() - graph or rdf library missing')
+    }
+    let ns = vocab(rdf)
+    let group = rdf.namedNode(uri)
+    let rdfType = graph.any(group, null, ns.vcard('Group'))
+    if (!rdfType) {
+      console.warn(`Possibly invalid group '${uri}', missing type vcard:Group`)
+    }
+    this.uid = graph.anyValue(group, ns.vcard('hasUID'))
+    graph.match(group, ns.vcard('hasMember'))
+      .forEach(memberMatch => {
+        this.addMember(memberMatch.object)
+      })
+    return this
+  }
+}
+
+module.exports = GroupListing

--- a/src/permission-set.js
+++ b/src/permission-set.js
@@ -200,7 +200,7 @@ class PermissionSet {
    * @param [accessModes=[]] {string|NamedNode|Array} 'READ'/'WRITE' etc.
    * @param [origins=[]] {Array<String>} List of origins that are allowed access
    * @param [mailTos=[]] {Array<String>}
-   * @return {Authorization}
+   * @return {PermissionSet} Returns self, chainable
    */
   addAuthorizationFor (resourceUrl, inherit, agent, accessModes = [],
                        origins = [], mailTos = []) {
@@ -216,7 +216,7 @@ class PermissionSet {
       auth.addMailTo(mailTo)
     })
     this.addAuthorization(auth)
-    return auth
+    return this
   }
 
   /**

--- a/src/permission-set.js
+++ b/src/permission-set.js
@@ -17,8 +17,9 @@
  */
 
 const Authorization = require('./authorization')
+const GroupListing = require('./group-listing')
 const { acl } = require('./modes')
-const ns = require('solid-namespace')
+const vocab = require('solid-namespace')
 
 const DEFAULT_ACL_SUFFIX = '.acl'
 const DEFAULT_CONTENT_TYPE = 'text/turtle'
@@ -34,25 +35,25 @@ const CONTAINER = 'container'
 const AGENT_INDEX = 'agents'
 const GROUP_INDEX = 'groups'
 
-/**
- * @class PermissionSet
- * @param resourceUrl {String} URL of the resource to which this PS applies
- * @param aclUrl {String} URL of the ACL corresponding to the resource
- * @param isContainer {Boolean} Is the resource a container? (Affects usage of
- *   inherit semantics / acl:default)
- * @param [options={}] {Object} Options hashmap
- * @param [options.graph] {Graph} Parsed RDF graph of the ACL resource
- * @param [options.rdf] {RDF} RDF Library
- * @param [options.strictOrigin] {Boolean} Enforce strict origin?
- * @param [options.host] {String} Actual request uri
- * @param [options.origin] {String} Origin URI to enforce, relevant
- *   if strictOrigin is set to true
- * @param [options.webClient] {SolidWebClient} Used for save() and clear()
- * @param [options.isAcl] {Function}
- * @param [options.aclUrlFor] {Function}
- * @constructor
- */
 class PermissionSet {
+  /**
+   * @class PermissionSet
+   * @param resourceUrl {String} URL of the resource to which this PS applies
+   * @param aclUrl {String} URL of the ACL corresponding to the resource
+   * @param isContainer {Boolean} Is the resource a container? (Affects usage of
+   *   inherit semantics / acl:default)
+   * @param [options={}] {Object} Options hashmap
+   * @param [options.graph] {Graph} Parsed RDF graph of the ACL resource
+   * @param [options.rdf] {RDF} RDF Library
+   * @param [options.strictOrigin] {Boolean} Enforce strict origin?
+   * @param [options.host] {String} Actual request uri
+   * @param [options.origin] {String} Origin URI to enforce, relevant
+   *   if strictOrigin is set to true
+   * @param [options.webClient] {SolidWebClient} Used for save() and clear()
+   * @param [options.isAcl] {Function}
+   * @param [options.aclUrlFor] {Function}
+   * @constructor
+   */
   constructor (resourceUrl, aclUrl, isContainer, options = {}) {
     /**
      * Hashmap of all Authorizations in this permission set, keyed by a hashed
@@ -76,13 +77,19 @@ class PermissionSet {
     this.host = options.host
     /**
      * Initialize the agents / groups / resources indexes.
-     * @property index
+     * @property authsBy
      * @type {Object}
      */
-    this.index = {
-      'agents': {},
-      'groups': {}  // Also includes Public permissions
+    this.authsBy = {
+      'agents': {},  // Auths by agent webId
+      'groups': {}  // Auths by group webId (also includes Public / EVERYONE)
     }
+    /**
+     * Cache of GroupListing objects, by group webId. Populated by `loadGroups()`.
+     * @property groups
+     * @type {Object}
+     */
+    this.groups = {}
     /**
      * RDF Library (optionally injected)
      * @property rdf
@@ -158,9 +165,9 @@ class PermissionSet {
       this.addControlPermissionsFor(auth)
     }
     // Create the appropriate indexes
-    this.addToAgentIndex(auth.webId(), auth.accessType, auth.resourceUrl, auth)
-    if (auth.isPublic()) {
-      this.addToPublicIndex(auth.resourceUrl, auth.accessType, auth)
+    this.addToAgentIndex(auth)
+    if (auth.isPublic() || auth.isGroup()) {
+      this.addToGroupIndex(auth)
     }
     return this
   }
@@ -173,16 +180,20 @@ class PermissionSet {
    * @private
    * @param resourceUrl {String}
    * @param inherit {Boolean}
-   * @param agent {String|Quad} Agent URL (or `acl:agent` RDF triple).
-   * @param accessModes {String} 'READ'/'WRITE' etc.
+   * @param agent {string|Quad|GroupListing} Agent URL (or `acl:agent` RDF triple).
+   * @param [accessModes=[]] {string|NamedNode|Array} 'READ'/'WRITE' etc.
    * @param [origins=[]] {Array<String>} List of origins that are allowed access
    * @param [mailTos=[]] {Array<String>}
    * @return {Authorization}
    */
-  addAuthorizationFor (resourceUrl, inherit, agent, accessModes, origins = [],
-                       mailTos = []) {
+  addAuthorizationFor (resourceUrl, inherit, agent, accessModes = [],
+                       origins = [], mailTos = []) {
     let auth = new Authorization(resourceUrl, inherit)
-    auth.setAgent(agent)
+    if (agent instanceof GroupListing) {
+      auth.setGroup(agent.listing)
+    } else {
+      auth.setAgent(agent)
+    }
     auth.addMode(accessModes)
     auth.addOrigin(origins)
     mailTos.forEach(mailTo => {
@@ -217,6 +228,9 @@ class PermissionSet {
    * @return {PermissionSet} Returns self (chainable)
    */
   addGroupPermission (webId, accessMode) {
+    if (!this.resourceUrl) {
+      throw new Error('Cannot add a permission to a PermissionSet with no resourceUrl')
+    }
     var auth = new Authorization(this.resourceUrl, this.isAuthInherited())
     auth.setGroup(webId)
     auth.addMode(accessMode)
@@ -239,6 +253,9 @@ class PermissionSet {
     if (!accessMode) {
       throw new Error('addPermission() requires a valid accessMode')
     }
+    if (!this.resourceUrl) {
+      throw new Error('Cannot add a permission to a PermissionSet with no resourceUrl')
+    }
     var auth = new Authorization(this.resourceUrl, this.isAuthInherited())
     auth.setAgent(webId)
     auth.addMode(accessMode)
@@ -254,13 +271,13 @@ class PermissionSet {
    * Enables lookups via `findAuthByAgent()`.
    * @method addToAgentIndex
    * @private
-   * @param webId {String} Agent's Web ID
-   * @param accessType {String} Either `accessTo` or `default`
-   * @param resourceUrl {String}
    * @param authorization {Authorization}
    */
-  addToAgentIndex (webId, accessType, resourceUrl, authorization) {
-    let agents = this.index.agents
+  addToAgentIndex (authorization) {
+    let webId = authorization.webId()
+    let accessType = authorization.accessType
+    let resourceUrl = authorization.resourceUrl
+    let agents = this.authsBy.agents
     if (!agents[webId]) {
       agents[webId] = {}
     }
@@ -279,13 +296,13 @@ class PermissionSet {
    * Enables lookups via `findAuthByAgent()`.
    * @method addToGroupIndex
    * @private
-   * @param webId {String} Group's Web ID
-   * @param accessType {String} Either `accessTo` or `default`
-   * @param resourceUrl {String}
    * @param authorization {Authorization}
    */
-  addToGroupIndex (webId, accessType, resourceUrl, authorization) {
-    let groups = this.index.groups
+  addToGroupIndex (authorization) {
+    let webId = authorization.webId()
+    let accessType = authorization.accessType
+    let resourceUrl = authorization.resourceUrl
+    let groups = this.authsBy.groups
     if (!groups[webId]) {
       groups[webId] = {}
     }
@@ -297,20 +314,6 @@ class PermissionSet {
     } else {
       groups[webId][accessType][resourceUrl].mergeWith(authorization)
     }
-  }
-
-  /**
-   * Adds a given authorization to the "lookup by group id" index.
-   * Alias for `addToGroupIndex()`.
-   * Enables lookups via `findAuthByAgent()`.
-   * @method addToPublicIndex
-   * @private
-   * @param resourceUrl {String}
-   * @param accessType {String} Either `accessTo` or `default`
-   * @param authorization {Authorization}
-   */
-  addToPublicIndex (resourceUrl, accessType, auth) {
-    this.addToGroupIndex(acl.EVERYONE, accessType, resourceUrl, auth)
   }
 
   /**
@@ -373,16 +376,52 @@ class PermissionSet {
    * @param resourceUrl {String}
    * @param agentId {String}
    * @param accessMode {String} Access mode (read/write/control)
+   * @throws {Error}
    * @return {Promise<Boolean>}
    */
   checkAccess (resourceUrl, agentId, accessMode) {
-    let result
+    let result = false
+    // First, check to see if there is public access for this mode
     if (this.allowsPublic(accessMode, resourceUrl)) {
-      result = true
-    } else {
-      let auth = this.findAuthByAgent(agentId, resourceUrl)
-      result = auth && this.checkOrigin(auth) && auth.allowsMode(accessMode)
+      return Promise.resolve(true)
     }
+
+    // Next, see if there is an individual authorization (for a user or a group)
+    result = this.checkAccessForAgent(resourceUrl, agentId, accessMode)
+    if (result) { return Promise.resolve(result) }
+
+    // Failing that, a group authorization to which this agent belongs
+    return this.checkGroupAccess(resourceUrl, agentId, accessMode)
+  }
+
+  /**
+   * @param resourceUrl {String}
+   * @param agentId {String}
+   * @param accessMode {String} Access mode (read/write/control)
+   * @throws {Error}
+   * @return {Boolean}
+   */
+  checkAccessForAgent (resourceUrl, agentId, accessMode) {
+    let auth = this.findAuthByAgent(agentId, resourceUrl)
+    let result = auth && this.checkOrigin(auth) && auth.allowsMode(accessMode)
+    return result
+  }
+
+  /**
+   * @param resourceUrl {String}
+   * @param agentId {String}
+   * @param accessMode {String} Access mode (read/write/control)
+   * @throws {Error}
+   * @return {Promise<Boolean>}
+   */
+  checkGroupAccess (resourceUrl, agentId, accessMode) {
+    let result = false
+    let membershipMatches = this.groupsForMember(agentId)
+    membershipMatches.forEach(groupWebId => {
+      if (this.checkAccessForAgent(resourceUrl, groupWebId, accessMode)) {
+        result = true
+      }
+    })
     return Promise.resolve(result)
   }
 
@@ -494,7 +533,7 @@ class PermissionSet {
    * @return {Authorization}
    */
   findAuthByAgent (webId, resourceUrl, indexType = AGENT_INDEX) {
-    let index = this.index[indexType]
+    let index = this.authsBy[indexType]
     if (!index[webId]) {
       // There are no permissions at all for this agent
       return false
@@ -564,6 +603,35 @@ class PermissionSet {
   }
 
   /**
+   * Returns a list of webIds of groups to which this agent belongs.
+   * Note: Only checks loaded groups (assumes a previous `loadGroups()` call).
+   * @param agentId {string}
+   * @return {Array<string>}
+   */
+  groupsForMember (agentId) {
+    let loadedGroupIds = Object.keys(this.groups)
+    return loadedGroupIds
+      .filter(groupWebId => {
+        return this.groups[groupWebId].hasMember(agentId)
+      })
+  }
+
+  /**
+   * Returns a list of URIs of group authorizations in this permission set
+   * (those added via addGroupPermission(), etc).
+   * @param [excludePublic=true] {Boolean} Should agentClass Agent be excluded?
+   * @returns {Array<string>}
+   */
+  groupUris (excludePublic = true) {
+    let groupIndex = this.authsBy.groups
+    let uris = Object.keys(groupIndex)
+    if (excludePublic) {
+      uris = uris.filter((uri) => { return uri !== acl.EVERYONE })
+    }
+    return uris
+  }
+
+  /**
    * Creates and loads all the authorizations from a given RDF graph.
    * Used by `getPermissions()` and by the constructor (optionally).
    * Usage:
@@ -576,14 +644,14 @@ class PermissionSet {
    * @param graph {Dataset} RDF Graph (parsed from the source ACL)
    */
   initFromGraph (graph) {
-    let vocab = ns(this.rdf)
-    let authSections = graph.match(null, null, vocab.acl('Authorization'))
+    let ns = vocab(this.rdf)
+    let authSections = graph.match(null, null, ns.acl('Authorization'))
     if (authSections.length) {
       authSections = authSections.map(match => { return match.subject })
     } else {
       // Attempt to deal with an ACL with no acl:Authorization types present.
       let subjects = {}
-      authSections = graph.match(null, vocab.acl('mode'))
+      authSections = graph.match(null, ns.acl('mode'))
       authSections.forEach(match => {
         subjects[match.subject.value] = match.subject
       })
@@ -594,21 +662,24 @@ class PermissionSet {
     // Iterate through each grouping of authorizations in the .acl graph
     authSections.forEach(fragment => {
       // Extract the access modes
-      let accessModes = graph.match(fragment, vocab.acl('mode'))
+      let accessModes = graph.match(fragment, ns.acl('mode'))
       // Extract allowed origins
-      let origins = graph.match(fragment, vocab.acl('origin'))
+      let origins = graph.match(fragment, ns.acl('origin'))
 
       // Extract all the authorized agents
-      let agentMatches = graph.match(fragment, vocab.acl('agent'))
+      let agentMatches = graph.match(fragment, ns.acl('agent'))
       // Mailtos only apply to agents (not groups)
       let mailTos = agentMatches.filter(isMailTo)
       // Now filter out mailtos
       agentMatches = agentMatches.filter(ea => { return !isMailTo(ea) })
       // Extract all 'Public' matches (agentClass foaf:Agent)
-      let publicMatches = graph.match(fragment, vocab.acl('agentClass'),
-        vocab.foaf('Agent'))
+      let publicMatches = graph.match(fragment, ns.acl('agentClass'),
+        ns.foaf('Agent'))
       // Extract all acl:agentGroup matches
-      let groupMatches = graph.match(fragment, vocab.acl('agentGroup'))
+      let groupMatches = graph.match(fragment, ns.acl('agentGroup'))
+      groupMatches = groupMatches.map(ea => {
+        return new GroupListing({ listing: ea })
+      })
       // Create an Authorization object for each group (accessTo and default)
       let allAgents = agentMatches
         .concat(publicMatches)
@@ -617,15 +688,15 @@ class PermissionSet {
       //   (both individual (acl:accessTo) and inherited (acl:default))
       allAgents.forEach(agentMatch => {
         // Extract the acl:accessTo statements.
-        let accessToMatches = graph.match(fragment, vocab.acl('accessTo'))
+        let accessToMatches = graph.match(fragment, ns.acl('accessTo'))
         accessToMatches.forEach(resourceMatch => {
           let resourceUrl = resourceMatch.object.value
           this.addAuthorizationFor(resourceUrl, acl.NOT_INHERIT,
             agentMatch, accessModes, origins, mailTos)
         })
         // Extract inherited / acl:default statements
-        let inheritedMatches = graph.match(fragment, vocab.acl('default'))
-          .concat(graph.match(fragment, vocab.acl('defaultForNew')))
+        let inheritedMatches = graph.match(fragment, ns.acl('default'))
+          .concat(graph.match(fragment, ns.acl('defaultForNew')))
         inheritedMatches.forEach(containerMatch => {
           let containerUrl = containerMatch.object.value
           this.addAuthorizationFor(containerUrl, acl.INHERIT,
@@ -652,6 +723,37 @@ class PermissionSet {
    */
   isEmpty () {
     return this.count === 0
+  }
+
+  /**
+   * @method loadGroups
+   * @param [options={}]
+   * @param [options.fetchGraph] {Function} Injected, returns a parsed graph of
+   *   a remote document (group listing). Required.
+   * @param [options.rdf] {RDF} RDF library
+   * @throws {Error}
+   * @return {Promise<PermissionSet>} Resolves to self, chainable
+   */
+  loadGroups (options = {}) {
+    let fetchGraph = options.fetchGraph
+    let rdf = options.rdf || this.rdf
+    if (!fetchGraph) {
+      return Promise.reject(new Error('Cannot load groups, fetchGraph() not supplied'))
+    }
+    if (!rdf) {
+      return Promise.reject(new Error('Cannot load groups, rdf librar not supplied'))
+    }
+    let uris = this.groupUris()
+    let loadActions = uris.map(uri => {
+      return GroupListing.loadFrom(uri, fetchGraph, rdf, options)
+    })
+    return Promise.all(loadActions)
+      .then(groups => {
+        groups.forEach(group => {
+          if (group) { this.groups[group.uri] = group }
+        })
+        return this
+      })
   }
 
   /**
@@ -760,7 +862,7 @@ class PermissionSet {
     }
     let graph = this.buildGraph(rdf)
     let target = null
-    let base = null
+    let base = this.aclUrl
     return new Promise((resolve, reject) => {
       rdf.serialize(target, graph, base, contentType, (err, result) => {
         if (err) { return reject(err) }

--- a/test/resources/acl-with-group-ttl.js
+++ b/test/resources/acl-with-group-ttl.js
@@ -1,0 +1,16 @@
+module.exports = `@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<#authorization1>
+    a acl:Authorization;
+
+    acl:agent
+        <https://alice.example.com/#me>;
+    acl:agentGroup
+        <https://alice.example.com/work-groups#Accounting>;
+    acl:accessTo <https://alice.example.com/docs/file2.ttl>;
+    acl:mode
+        acl:Read, acl:Write, acl:Control;
+
+    acl:origin
+        <https://example.com/>.`

--- a/test/resources/group-listing-ttl.js
+++ b/test/resources/group-listing-ttl.js
@@ -1,0 +1,24 @@
+module.exports = `# Contents of https://alice.example.com/work-groups
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<#this> a acl:GroupListing.
+
+<#Accounting>
+  a vcard:Group;
+  vcard:hasUID <urn:uuid:8831CBAD-1111-2222-8563-F0F4787E5398:ABGroup>;
+  dct:created "2013-09-11T07:18:19+0000"^^xsd:dateTime;
+  dct:modified "2015-08-08T14:45:15+0000"^^xsd:dateTime;
+
+  # Accounting group members:
+  vcard:hasMember <https://bob.example.com/profile/card#me>;
+  vcard:hasMember <https://candice.example.com/profile/card#me>.
+
+<#Management>
+  a vcard:Group;
+  vcard:hasUID <urn:uuid:8831CBAD-3333-4444-8563-F0F4787E5398:ABGroup>;
+
+  # Management group members:
+  vcard:hasMember <https://deb.example.com/profile/card#me>.`

--- a/test/unit/authorization-test.js
+++ b/test/unit/authorization-test.js
@@ -1,8 +1,9 @@
 'use strict'
 
-var test = require('tape')
-// var rdf = require('rdflib')
-var Authorization = require('../../src/authorization')
+const test = require('tape')
+const rdf = require('rdflib')
+const ns = require('solid-namespace')(rdf)
+const Authorization = require('../../src/authorization')
 const { acl } = require('../../src/modes')
 
 const resourceUrl = 'https://bob.example.com/docs/file1'
@@ -10,7 +11,7 @@ const agentWebId = 'https://bob.example.com/profile/card#me'
 // Not really sure what group webIDs will look like, not yet implemented:
 const groupWebId = 'https://devteam.example.com/something'
 
-test('a new Authorization()', function (t) {
+test('a new Authorization()', t => {
   let auth = new Authorization()
   t.notOk(auth.isAgent())
   t.notOk(auth.isGroup())
@@ -27,7 +28,7 @@ test('a new Authorization()', function (t) {
   t.end()
 })
 
-test('a new Authorization for a container', function (t) {
+test('a new Authorization for a container', t => {
   let auth = new Authorization(resourceUrl, acl.INHERIT)
   t.equal(auth.resourceUrl, resourceUrl)
   t.notOk(auth.webId())
@@ -41,14 +42,14 @@ test('a new Authorization for a container', function (t) {
   t.end()
 })
 
-test('Authorization allowsMode() test', function (t) {
+test('Authorization allowsMode() test', t => {
   let auth = new Authorization()
   auth.addMode(acl.WRITE)
   t.ok(auth.allowsMode(acl.WRITE), 'auth.allowsMode() should work')
   t.end()
 })
 
-test('an Authorization allows editing permission modes', function (t) {
+test('an Authorization allows editing permission modes', t => {
   let auth = new Authorization()
   auth.addMode(acl.CONTROL)
   t.notOk(auth.isEmpty(), 'Adding an access mode means no longer empty')
@@ -79,7 +80,7 @@ test('an Authorization allows editing permission modes', function (t) {
   t.end()
 })
 
-test('an Authorization can add or remove multiple modes', function (t) {
+test('an Authorization can add or remove multiple modes', t => {
   let auth = new Authorization()
   auth.addMode([acl.READ, acl.WRITE, acl.CONTROL])
   t.ok(auth.allowsRead() && auth.allowsWrite() && auth.allowsControl())
@@ -89,7 +90,7 @@ test('an Authorization can add or remove multiple modes', function (t) {
   t.end()
 })
 
-test('an Authorization can only have either an agent or a group', function (t) {
+test('an Authorization can only have either an agent or a group', t => {
   let auth1 = new Authorization()
   auth1.setAgent(agentWebId)
   t.equal(auth1.agent, agentWebId)
@@ -107,7 +108,7 @@ test('an Authorization can only have either an agent or a group', function (t) {
   t.end()
 })
 
-test('acl.WRITE implies acl.APPEND', function (t) {
+test('acl.WRITE implies acl.APPEND', t => {
   let auth = new Authorization()
   auth.addMode(acl.WRITE)
   t.ok(auth.allowsWrite())
@@ -127,7 +128,7 @@ test('acl.WRITE implies acl.APPEND', function (t) {
   t.end()
 })
 
-test('an Authorization can grant Public access', function (t) {
+test('an Authorization can grant Public access', t => {
   let auth = new Authorization()
   t.notOk(auth.isPublic(), 'An authorization is not public access by default')
 
@@ -150,7 +151,7 @@ test('an Authorization can grant Public access', function (t) {
   t.end()
 })
 
-test('an webId is either the agent or the group id', function (t) {
+test('an webId is either the agent or the group id', t => {
   let auth = new Authorization()
   auth.setAgent(agentWebId)
   t.equal(auth.webId(), auth.agent)
@@ -160,7 +161,7 @@ test('an webId is either the agent or the group id', function (t) {
   t.end()
 })
 
-test('hashFragment() on an incomplete authorization should fail', function (t) {
+test('hashFragment() on an incomplete authorization should fail', t => {
   let auth = new Authorization()
   t.throws(function () {
     auth.hashFragment()
@@ -172,7 +173,7 @@ test('hashFragment() on an incomplete authorization should fail', function (t) {
   t.end()
 })
 
-test('Authorization.isValid() test', function (t) {
+test('Authorization.isValid() test', t => {
   let auth = new Authorization()
   t.notOk(auth.isValid(), 'An empty authorization should not be valid')
   auth.resourceUrl = resourceUrl
@@ -187,7 +188,7 @@ test('Authorization.isValid() test', function (t) {
   t.end()
 })
 
-test('Authorization origins test', function (t) {
+test('Authorization origins test', t => {
   let auth = new Authorization()
   let origin = 'https://example.com/'
   auth.addOrigin(origin)
@@ -199,14 +200,14 @@ test('Authorization origins test', function (t) {
   t.end()
 })
 
-test('Comparing Authorizations test 1', function (t) {
+test('Comparing Authorizations test 1', t => {
   let auth1 = new Authorization()
   let auth2 = new Authorization()
   t.ok(auth1.equals(auth2))
   t.end()
 })
 
-test('Comparing Authorizations test 2', function (t) {
+test('Comparing Authorizations test 2', t => {
   let auth1 = new Authorization(resourceUrl)
   let auth2 = new Authorization()
   t.notOk(auth1.equals(auth2))
@@ -215,7 +216,7 @@ test('Comparing Authorizations test 2', function (t) {
   t.end()
 })
 
-test('Comparing Authorizations test 3', function (t) {
+test('Comparing Authorizations test 3', t => {
   let auth1 = new Authorization()
   auth1.setAgent(agentWebId)
   let auth2 = new Authorization()
@@ -225,7 +226,7 @@ test('Comparing Authorizations test 3', function (t) {
   t.end()
 })
 
-test('Comparing Authorizations test 4', function (t) {
+test('Comparing Authorizations test 4', t => {
   let auth1 = new Authorization()
   auth1.addMode([acl.READ, acl.WRITE])
   let auth2 = new Authorization()
@@ -235,7 +236,7 @@ test('Comparing Authorizations test 4', function (t) {
   t.end()
 })
 
-test('Comparing Authorizations test 5', function (t) {
+test('Comparing Authorizations test 5', t => {
   let auth1 = new Authorization(resourceUrl, acl.INHERIT)
   let auth2 = new Authorization(resourceUrl)
   t.notOk(auth1.equals(auth2))
@@ -244,7 +245,7 @@ test('Comparing Authorizations test 5', function (t) {
   t.end()
 })
 
-test('Comparing Authorizations test 6', function (t) {
+test('Comparing Authorizations test 6', t => {
   let auth1 = new Authorization()
   auth1.addMailTo('alice@example.com')
   let auth2 = new Authorization()
@@ -254,7 +255,7 @@ test('Comparing Authorizations test 6', function (t) {
   t.end()
 })
 
-test('Comparing Authorizations test 7', function (t) {
+test('Comparing Authorizations test 7', t => {
   let origin = 'https://example.com/'
   let auth1 = new Authorization()
   auth1.addOrigin(origin)
@@ -265,10 +266,25 @@ test('Comparing Authorizations test 7', function (t) {
   t.end()
 })
 
-test('Authorization.clone() test', function (t) {
+test('Authorization.clone() test', t => {
   let auth1 = new Authorization(resourceUrl, acl.INHERIT)
   auth1.addMode([acl.READ, acl.WRITE])
   let auth2 = auth1.clone()
   t.ok(auth1.equals(auth2))
+  t.end()
+})
+
+test('Authorization serialize group test', t => {
+  let auth = new Authorization(resourceUrl)
+  auth.addMode(acl.READ)
+  let groupUrl = 'https://example.com/work-group'
+  auth.setGroup(groupUrl)
+  // Serialize the authorization
+  let triples = auth.rdfStatements(rdf)
+  let groupTriple = triples.find((triple) => {
+    return triple.predicate.equals(ns.acl('agentGroup'))
+  })
+  t.ok(groupTriple, 'Serialized auth should have an agentGroup triple')
+  t.equals(groupTriple.object.value, groupUrl)
   t.end()
 })

--- a/test/unit/check-access-test.js
+++ b/test/unit/check-access-test.js
@@ -113,9 +113,6 @@ test('PermissionSet checkAccess() with remote Group Listings', t => {
   let groupListingSource = require('../resources/group-listing-ttl')
   let listingUri = 'https://alice.example.com/work-groups'
   let groupUri = listingUri + '#Accounting'
-  // let fetchGraph = () => {
-  //   return parseGraph(rdf, listingUri, groupListingSource)
-  // }
   let fetchGraph = sinon.stub()
     .returns(parseGraph(rdf, listingUri, groupListingSource))
   let options = { fetchGraph }
@@ -127,18 +124,11 @@ test('PermissionSet checkAccess() with remote Group Listings', t => {
   parseGraph(rdf, aclUrl, groupAclSource)
     .then(graph => {
       ps.initFromGraph(graph)
-      return ps.checkAccess(resourceUrl, bob, acl.WRITE)
+      return ps.checkAccess(resourceUrl, bob, acl.WRITE, options)
     })
     .then(hasAccess => {
-      t.notOk(hasAccess, 'Bob should not have access before groups loaded')
-      return ps.loadGroups(options)
-    })
-    .then(ps => {
-      t.ok(fetchGraph.calledWith(groupUri, options))
       // External group listings have now been loaded/resolved
-      return ps.checkAccess(resourceUrl, bob, acl.WRITE)
-    })
-    .then(hasAccess => {
+      t.ok(fetchGraph.calledWith(groupUri, options))
       t.ok(hasAccess, 'Bob should have access as member of group')
       t.end()
     })

--- a/test/unit/check-access-test.js
+++ b/test/unit/check-access-test.js
@@ -1,7 +1,10 @@
 'use strict'
 
 const test = require('tape')
+const sinon = require('sinon')
 const Authorization = require('../../src/authorization')
+const rdf = require('rdflib')
+const { parseGraph } = require('./utils')
 const { acl } = require('../../src/modes')
 const PermissionSet = require('../../src/permission-set')
 const aliceWebId = 'https://alice.example.com/#me'
@@ -14,11 +17,11 @@ test('PermissionSet checkAccess() test - Append access', t => {
   ps.checkAccess(resourceUrl, aliceWebId, acl.APPEND)
     .then(result => {
       t.ok(result, 'Alice should have Append access implied by Write access')
+      t.end()
     })
     .catch(err => {
       t.fail(err)
     })
-  t.end()
 })
 
 test('PermissionSet checkAccess() test - accessTo', function (t) {
@@ -30,20 +33,16 @@ test('PermissionSet checkAccess() test - accessTo', function (t) {
   ps.checkAccess(containerUrl, aliceWebId, acl.WRITE)
     .then(result => {
       t.ok(result, 'Alice should have write access to container')
+      return ps.checkAccess(containerUrl, 'https://someone.else.com/', acl.WRITE)
     })
-    .catch(err => {
-      console.log(err)
-      t.fail(err)
-    })
-  ps.checkAccess(containerUrl, 'https://someone.else.com/', acl.WRITE)
     .then(result => {
       t.notOk(result, 'Another user should have no write access')
+      t.end()
     })
     .catch(err => {
       console.log(err)
       t.fail(err)
     })
-  t.end()
 })
 
 test('PermissionSet checkAccess() test - default/inherited', function (t) {
@@ -58,21 +57,17 @@ test('PermissionSet checkAccess() test - default/inherited', function (t) {
   ps.checkAccess(resourceUrl, aliceWebId, acl.READ)
     .then(result => {
       t.ok(result, 'Alice should have inherited read access to file')
+      let randomUser = 'https://someone.else.com/'
+      return ps.checkAccess(resourceUrl, randomUser, acl.READ)
     })
-    .catch(err => {
-      console.log(err)
-      t.fail(err)
-    })
-  let randomUser = 'https://someone.else.com/'
-  ps.checkAccess(resourceUrl, randomUser, acl.READ)
     .then(result => {
       t.notOk(result, 'Another user should not have inherited access to file')
+      t.end()
     })
     .catch(err => {
       console.log(err)
       t.fail(err)
     })
-  t.end()
 })
 
 test('PermissionSet checkAccess() test - public access', function (t) {
@@ -92,25 +87,63 @@ test('PermissionSet checkAccess() test - public access', function (t) {
   ps.checkAccess(resourceUrl, randomUser, acl.READ)
     .then(result => {
       t.ok(result, 'Everyone should have inherited read access to file')
+      // Reset the permission set, test a non-default permission
+      ps = new PermissionSet()
+      let auth2 = new Authorization(resourceUrl, !inherit)
+      auth2.setPublic()
+      auth2.addMode(acl.READ)
+      ps.addAuthorization(auth2)
+      return ps.checkAccess(resourceUrl, randomUser, acl.READ)
     })
-    .catch(err => {
-      console.log(err)
-      t.fail(err)
-    })
-  // Reset the permission set, test a non-default permission
-  ps = new PermissionSet()
-  let auth2 = new Authorization(resourceUrl, !inherit)
-  auth2.setPublic()
-  auth2.addMode(acl.READ)
-  ps.addAuthorization(auth2)
-  ps.checkAccess(resourceUrl, randomUser, acl.READ)
     .then(result => {
       t.ok(result, 'Everyone should have non-inherited read access to file')
+      t.end()
     })
     .catch(err => {
       console.log(err)
       t.fail(err)
     })
+})
 
-  t.end()
+test('PermissionSet checkAccess() with remote Group Listings', t => {
+  let groupAclSource = require('../resources/acl-with-group-ttl')
+  let resourceUrl = 'https://alice.example.com/docs/file2.ttl'
+  let aclUrl = 'https://alice.example.com/docs/file2.ttl.acl'
+
+  let groupListingSource = require('../resources/group-listing-ttl')
+  let listingUri = 'https://alice.example.com/work-groups'
+  let groupUri = listingUri + '#Accounting'
+  // let fetchGraph = () => {
+  //   return parseGraph(rdf, listingUri, groupListingSource)
+  // }
+  let fetchGraph = sinon.stub()
+    .returns(parseGraph(rdf, listingUri, groupListingSource))
+  let options = { fetchGraph }
+
+  let bob = 'https://bob.example.com/profile/card#me'
+  let isContainer = false
+  let ps = new PermissionSet(resourceUrl, aclUrl, isContainer, { rdf })
+
+  parseGraph(rdf, aclUrl, groupAclSource)
+    .then(graph => {
+      ps.initFromGraph(graph)
+      return ps.checkAccess(resourceUrl, bob, acl.WRITE)
+    })
+    .then(hasAccess => {
+      t.notOk(hasAccess, 'Bob should not have access before groups loaded')
+      return ps.loadGroups(options)
+    })
+    .then(ps => {
+      t.ok(fetchGraph.calledWith(groupUri, options))
+      // External group listings have now been loaded/resolved
+      return ps.checkAccess(resourceUrl, bob, acl.WRITE)
+    })
+    .then(hasAccess => {
+      t.ok(hasAccess, 'Bob should have access as member of group')
+      t.end()
+    })
+    .catch(err => {
+      console.log(err)
+      t.fail(err)
+    })
 })

--- a/test/unit/group-listing-test.js
+++ b/test/unit/group-listing-test.js
@@ -1,0 +1,60 @@
+'use strict'
+const test = require('tape')
+const sinon = require('sinon')
+const rdf = require('rdflib')
+const { parseGraph } = require('./utils')
+const GroupListing = require('../../src/group-listing')
+const groupListingSource = require('../resources/group-listing-ttl')
+const listingUri = 'https://example.com/groups'
+
+test('GroupListing empty group test', t => {
+  let group = new GroupListing()
+  t.equals(group.count, 0, 'A new group should have no members')
+  t.notOk(group.uid, 'A new group should have no group UID')
+  t.end()
+})
+
+test('GroupListing addMember test', t => {
+  let group = new GroupListing()
+  let bobWebId = 'https://bob.com/#i'
+  group.addMember(bobWebId)
+  t.equals(group.count, 1)
+  t.ok(group.hasMember(bobWebId))
+  t.end()
+})
+
+test('GroupListing initFromGraph()', t => {
+  let group = new GroupListing({ listing: listingUri })
+  t.equals(group.listing, listingUri)
+  let groupUri = listingUri + '#Accounting'
+
+  parseGraph(rdf, listingUri, groupListingSource)
+    .then(graph => {
+      group.initFromGraph(groupUri, graph, rdf)
+      t.ok(group.uid, 'Group vcard:hasUID should have been parsed')
+      t.equals(group.count, 2, 'Two members should have been parsed')
+      t.ok(group.hasMember('https://bob.example.com/profile/card#me'))
+      t.end()
+    })
+    .catch(err => {
+      console.log(err)
+      t.fail(err)
+    })
+})
+
+test('GroupListing.loadFrom test', t => {
+  let groupUri = listingUri + '#Accounting'
+  let fetchGraph = sinon.stub()
+    .returns(parseGraph(rdf, listingUri, groupListingSource))
+  let options = {}
+  GroupListing.loadFrom(groupUri, fetchGraph, rdf, options)
+    .then(group => {
+      t.equals(group.count, 2, 'Two members should have been parsed')
+      t.ok(fetchGraph.calledWith(groupUri, options))
+      t.end()
+    })
+    .catch(err => {
+      console.log(err)
+      t.fail(err)
+    })
+})

--- a/test/unit/permission-set-test.js
+++ b/test/unit/permission-set-test.js
@@ -38,6 +38,8 @@ test('a new PermissionSet()', function (t) {
   t.equal(ps.count, 0, 'should have a count of 0')
   t.notOk(ps.resourceUrl, 'should have a null resource url')
   t.notOk(ps.aclUrl, 'should have a null acl url')
+  t.deepEqual(ps.allAuthorizations(), [])
+  t.notOk(ps.hasGroups(), 'should have no group auths')
   t.end()
 })
 
@@ -387,14 +389,16 @@ test('PermissionSet parsing acl with agentGroup', t => {
 test('PermissionSet groupUris() test', t => {
   let resourceUrl = 'https://alice.example.com/docs/file2.ttl'
   let ps = new PermissionSet(resourceUrl)
+  ps.addGroupPermission(acl.EVERYONE, acl.READ)
+  // By default, groupUris() excludes the Public agentClass
   t.deepEquals(ps.groupUris(), [])
+  t.notOk(ps.hasGroups())
   let groupUrl = 'https://alice.example.com/work-groups#Accounting'
   ps.addGroupPermission(groupUrl, acl.WRITE)
-  ps.addGroupPermission(acl.EVERYONE, acl.READ)
-
-  // By default, groupUris() excludes the Public agentClass
   t.equals(ps.groupUris().length, 1)
+  t.ok(ps.hasGroups())
   let excludePublic = false
   t.equals(ps.groupUris(excludePublic).length, 2)
   t.end()
 })
+

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,0 +1,18 @@
+'use strict'
+const rdf = require('rdflib')
+
+function parseGraph (rdf, baseUrl, rdfSource, contentType = 'text/turtle') {
+  let graph = rdf.graph()
+  return new Promise((resolve, reject) => {
+    rdf.parse(rdfSource, graph, baseUrl, contentType, (err, result) => {
+      if (err) { return reject(err) }
+      if (!result) {
+        return reject(new Error('Error serializing the graph to ' +
+          contentType))
+      }
+      resolve(result)
+    })
+  })
+}
+
+module.exports.parseGraph = parseGraph


### PR DESCRIPTION
See https://github.com/solid/web-access-control-spec#groups-of-agents for specs

The usage is mostly unchanged; the main difference is that now the consuming code should pass a `fetchGraph()` function in the `options` parameter of `ps.checkAccess()`, so that it can load (local or remote) group listings.

