### PR TITLE
More logging when authorization is not granted

### DIFF
--- a/src/permission-set.js
+++ b/src/permission-set.js
@@ -411,25 +411,22 @@ class PermissionSet {
       return Promise.resolve(true)
     }
 
-    let groupaccess = Promise.resolve(false); 
     if (this.hasGroups()) {
       // Lastly, load the remote group listings, and check for group auth
       debug('Check groups authorizations')
 
-      groupaccess = this.loadGroups(options)
+      return this.loadGroups(options)
 	    .then(() => {
 		return this.checkGroupAccess(resourceUrl, agentId, accessMode, options)
 	    })
+    }
 
+    // Then, access will not be granted
+    debug('Can agent ' + agentId + ' ' + accessMode + ' ' + resourceUrl + '?')
+    if (this.origin) {
+      debug('Can origin ' + this.origin + ' ' + accessMode + ' ' + resourceUrl + '?')
     }
-    if (!groupaccess) {
-      // Then, access will not be granted
-      debug('Can agent ' + agentId + ' ' + accessMode + ' ' + resourceUrl + '?')
-      if (this.origin) {
-        debug('Can origin ' + this.origin + ' ' + accessMode + ' ' + resourceUrl + '?')
-      }
-    }
-    return groupaccess;
+    return Promise.resolve(false);
   }
 
   /**


### PR DESCRIPTION
I decided to look for low-hanging fruit and ended up taking a look at https://github.com/solid/node-solid-server/issues/468 I found that the logging part of that issue is best resolved in this package, but the HTTP error part is harder because NSS' ACLChecker doesn't know why authorization wasn't granted, and so didn't fit my definition of low-hanging fruit. Also, I haven't worked with promises before, so I was not inclined to make changes I didn't grok.

I put in quite a lot of logging when I worked with Group ACLs, and it is now pretty chatty, therefore, I'm not sure this patch is such a good idea. We should probably have a better logging framework with several log levels to choose from. I seems to work, so I put it up there for your review.

